### PR TITLE
Converted links in documentation from [url] to just url, and made lin…

### DIFF
--- a/sqlite3/backup.go
+++ b/sqlite3/backup.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Backup is a handle to an online backup operation between two databases.
-// [http://www.sqlite.org/c3ref/backup.html]
+// https://www.sqlite.org/c3ref/backup.html
 type Backup struct {
 	src  *Conn
 	dst  *Conn
@@ -38,7 +38,7 @@ func newBackup(src *Conn, srcName string, dst *Conn, dstName string) (*Backup, e
 
 // Close releases all resources associated with the backup operation. It is safe
 // to call this method prior to backup completion to abort the operation.
-// [http://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupfinish]
+// https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupfinish
 func (b *Backup) Close() error {
 	if bkup := b.bkup; bkup != nil {
 		b.bkup = nil
@@ -59,7 +59,7 @@ func (b *Backup) Conn() (src, dst *Conn) {
 // Step copies up to n pages to the destination database. If n is negative, all
 // remaining pages are copied. io.EOF is returned upon successful backup
 // completion.
-// [http://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep]
+// https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep
 func (b *Backup) Step(n int) error {
 	if b.bkup == nil {
 		return ErrBadBackup
@@ -79,7 +79,7 @@ func (b *Backup) Step(n int) error {
 // each call to Step and are reset to 0 after the backup is closed. The total
 // number of pages may change if the source database is modified during the
 // backup operation.
-// [http://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupremaining]
+// https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupremaining
 func (b *Backup) Progress() (remaining, total int) {
 	if b.bkup != nil {
 		remaining = int(C.sqlite3_backup_remaining(b.bkup))

--- a/sqlite3/const.go
+++ b/sqlite3/const.go
@@ -10,7 +10,7 @@ package sqlite3
 import "C"
 
 // Fundamental SQLite data types. These are returned by Stmt.DataTypes method.
-// [http://www.sqlite.org/c3ref/c_blob.html]
+// https://www.sqlite.org/c3ref/c_blob.html
 const (
 	INTEGER = C.SQLITE_INTEGER // 1
 	FLOAT   = C.SQLITE_FLOAT   // 2
@@ -20,7 +20,7 @@ const (
 )
 
 // Flags that can be provided to Open
-// [https://www.sqlite.org/c3ref/open.html]
+// https://www.sqlite.org/c3ref/open.html
 const (
 	OPEN_READONLY       = C.SQLITE_OPEN_READONLY       // Ok for sqlite3_open_v2()
 	OPEN_READWRITE      = C.SQLITE_OPEN_READWRITE      // Ok for sqlite3_open_v2()
@@ -48,7 +48,7 @@ const (
 // OK and ROW become nil, and DONE becomes either nil or io.EOF, depending on
 // the context in which the statement is executed. All other codes are returned
 // via the Error struct.
-// [http://www.sqlite.org/c3ref/c_abort.html]
+// https://www.sqlite.org/c3ref/c_abort.html
 const (
 	OK         = C.SQLITE_OK         // 0   = Successful result
 	ERROR      = C.SQLITE_ERROR      // 1   = SQL error or missing database
@@ -86,7 +86,7 @@ const (
 // Extended result codes returned by the SQLite API. Extended result codes are
 // enabled by default for all new Conn objects. Use Error.Code()&0xFF to convert
 // an extended code to a general one.
-// [http://www.sqlite.org/c3ref/c_abort_rollback.html]
+// https://www.sqlite.org/c3ref/c_abort_rollback.html
 const (
 	IOERR_READ              = C.SQLITE_IOERR_READ              // (SQLITE_IOERR | (1<<8))
 	IOERR_SHORT_READ        = C.SQLITE_IOERR_SHORT_READ        // (SQLITE_IOERR | (2<<8))
@@ -144,7 +144,7 @@ const (
 
 // Codes used by SQLite to indicate the operation type when invoking authorizer
 // and row update callbacks.
-// [http://www.sqlite.org/c3ref/c_alter_table.html]
+// https://www.sqlite.org/c3ref/c_alter_table.html
 const (
 	CREATE_INDEX        = C.SQLITE_CREATE_INDEX        // 1
 	CREATE_TABLE        = C.SQLITE_CREATE_TABLE        // 2
@@ -182,7 +182,7 @@ const (
 )
 
 // Core SQLite performance counters that can be queried with Status.
-// [http://www.sqlite.org/c3ref/c_status_malloc_count.html]
+// https://www.sqlite.org/c3ref/c_status_malloc_count.html
 const (
 	STATUS_MEMORY_USED        = C.SQLITE_STATUS_MEMORY_USED        // 0
 	STATUS_PAGECACHE_USED     = C.SQLITE_STATUS_PAGECACHE_USED     // 1
@@ -197,7 +197,7 @@ const (
 )
 
 // Connection performance counters that can be queried with Conn.Status.
-// [http://www.sqlite.org/c3ref/c_dbstatus_options.html]
+// https://www.sqlite.org/c3ref/c_dbstatus_options.html
 const (
 	DBSTATUS_LOOKASIDE_USED      = C.SQLITE_DBSTATUS_LOOKASIDE_USED      // 0
 	DBSTATUS_CACHE_USED          = C.SQLITE_DBSTATUS_CACHE_USED          // 1
@@ -213,7 +213,7 @@ const (
 )
 
 // Statement performance counters that can be queried with Stmt.Status.
-// [http://www.sqlite.org/c3ref/c_stmtstatus_counter.html]
+// https://www.sqlite.org/c3ref/c_stmtstatus_counter.html
 const (
 	STMTSTATUS_FULLSCAN_STEP = C.SQLITE_STMTSTATUS_FULLSCAN_STEP // 1
 	STMTSTATUS_SORT          = C.SQLITE_STMTSTATUS_SORT          // 2
@@ -222,7 +222,7 @@ const (
 )
 
 // Per-connection limits that can be queried and changed with Conn.Limit.
-// [http://www.sqlite.org/c3ref/c_limit_attached.html]
+// https://www.sqlite.org/c3ref/c_limit_attached.html
 const (
 	LIMIT_LENGTH              = C.SQLITE_LIMIT_LENGTH              // 0
 	LIMIT_SQL_LENGTH          = C.SQLITE_LIMIT_SQL_LENGTH          // 1

--- a/sqlite3/io.go
+++ b/sqlite3/io.go
@@ -23,7 +23,7 @@ var ErrBlobFull = &Error{ERROR, "incremental write failed, no space left"}
 // reading and writing. The value length cannot be changed using this API; use
 // an UPDATE statement for that. The recommended way of allocating space for a
 // BLOB is to use the ZeroBlob type or the zeroblob() SQL function.
-// [http://www.sqlite.org/c3ref/blob.html]
+// https://www.sqlite.org/c3ref/blob.html
 type BlobIO struct {
 	conn *Conn
 	blob *C.sqlite3_blob
@@ -60,7 +60,7 @@ func newBlobIO(c *Conn, db, tbl, col string, row int64, rw bool) (*BlobIO, error
 // It is important to check the error returned by this method, since disk I/O
 // and other types of errors may not be reported until the changes are actually
 // committed to the database.
-// [http://www.sqlite.org/c3ref/blob_close.html]
+// https://www.sqlite.org/c3ref/blob_close.html
 func (b *BlobIO) Close() error {
 	if blob := b.blob; blob != nil {
 		b.blob = nil
@@ -90,13 +90,13 @@ func (b *BlobIO) Row() int64 {
 // indicated by an ABORT error code returned from Read or Write. An expired
 // handle is closed automatically and cannot be reopened. Any writes that
 // occurred before the abort are not rolled back.
-// [http://www.sqlite.org/c3ref/blob_bytes.html]
+// https://www.sqlite.org/c3ref/blob_bytes.html
 func (b *BlobIO) Len() int {
 	return b.len
 }
 
 // Read implements the io.Reader interface.
-// [http://www.sqlite.org/c3ref/blob_read.html]
+// https://www.sqlite.org/c3ref/blob_read.html
 func (b *BlobIO) Read(p []byte) (n int, err error) {
 	if b.blob == nil {
 		return 0, ErrBadIO
@@ -114,7 +114,7 @@ func (b *BlobIO) Read(p []byte) (n int, err error) {
 // Write implements the io.Writer interface. The number of bytes written is
 // always either 0 or len(p). ErrBlobFull is returned if there isn't enough
 // space left to write all of p.
-// [http://www.sqlite.org/c3ref/blob_write.html]
+// https://www.sqlite.org/c3ref/blob_write.html
 func (b *BlobIO) Write(p []byte) (n int, err error) {
 	if b.blob == nil {
 		return 0, ErrBadIO
@@ -152,7 +152,7 @@ func (b *BlobIO) Seek(offset int64, whence int) (ret int64, err error) {
 // Reopen closes the current value and opens another one in the same column,
 // specified by its ROWID. If an error is encountered, the I/O handle becomes
 // unusable and is automatically closed.
-// [http://www.sqlite.org/c3ref/blob_reopen.html]
+// https://www.sqlite.org/c3ref/blob_reopen.html
 func (b *BlobIO) Reopen(row int64) error {
 	if b.blob == nil {
 		return ErrBadIO

--- a/sqlite3/sqlite3.go
+++ b/sqlite3/sqlite3.go
@@ -6,8 +6,8 @@ package sqlite3
 
 /*
 // SQLite compilation options.
-// [https://www.sqlite.org/compile.html]
-// [https://www.sqlite.org/footprint.html]
+// https://www.sqlite.org/compile.html
+// https://www.sqlite.org/footprint.html
 #cgo CFLAGS: -std=gnu99
 #cgo CFLAGS: -Os
 #cgo CFLAGS: -DNDEBUG=1
@@ -95,21 +95,21 @@ var initErr error
 
 func init() {
 	// Initialize SQLite (required with SQLITE_OMIT_AUTOINIT).
-	// [https://www.sqlite.org/c3ref/initialize.html]
+	// https://www.sqlite.org/c3ref/initialize.html
 	if rc := C.sqlite3_initialize(); rc != OK {
 		initErr = errStr(rc)
 		return
 	}
 
 	// Use the same temporary directory as Go.
-	// [https://www.sqlite.org/c3ref/temp_directory.html]
+	// https://www.sqlite.org/c3ref/temp_directory.html
 	tmp := os.TempDir() + "\x00"
 	C.set_temp_dir(cStr(tmp))
 }
 
 // Conn is a connection handle, which may have multiple databases attached to it
 // by using the ATTACH SQL statement.
-// [https://www.sqlite.org/c3ref/sqlite3.html]
+// https://www.sqlite.org/c3ref/sqlite3.html
 type Conn struct {
 	db *C.sqlite3
 }
@@ -120,7 +120,7 @@ type Conn struct {
 // which creates a temporary in-memory database, or 4) an empty string, which
 // creates a temporary on-disk database (deleted when closed) in the directory
 // returned by os.TempDir(). Flags to Open can optionally be provided.
-// [https://www.sqlite.org/c3ref/open.html]
+// https://www.sqlite.org/c3ref/open.html
 func Open(name string, flagArgs ...int) (*Conn, error) {
 	if len(flagArgs) > 1 {
 		return nil, pkgErr(MISUSE, "too many arguments provided to Open")
@@ -154,7 +154,7 @@ func Open(name string, flagArgs ...int) (*Conn, error) {
 // returned if the connection is left in this "zombie" status, which may
 // indicate a programming error where some previously allocated resource is not
 // properly released.
-// [https://www.sqlite.org/c3ref/close.html]
+// https://www.sqlite.org/c3ref/close.html
 func (c *Conn) Close() error {
 	if db := c.db; db != nil {
 		c.db = nil
@@ -175,7 +175,7 @@ func (c *Conn) Close() error {
 // this function can also bind arguments to the returned statement.  If an
 // error occurs during binding, the statement is closed/finalized and the error
 // is returned.
-// [https://www.sqlite.org/c3ref/prepare.html]
+// https://www.sqlite.org/c3ref/prepare.html
 func (c *Conn) Prepare(sql string, args ...interface{}) (s *Stmt, err error) {
 	zSQL := sql + "\x00"
 
@@ -214,7 +214,7 @@ func (c *Conn) Prepare(sql string, args ...interface{}) (s *Stmt, err error) {
 // are given.  If arguments are given, it's simply a convenient way to
 // Prepare a statement, Bind arguments, Step the statement to completion,
 // and Close/finalize the statement.
-// [https://www.sqlite.org/c3ref/exec.html]
+// https://www.sqlite.org/c3ref/exec.html
 func (c *Conn) Exec(sql string, args ...interface{}) error {
 	// Fast path via sqlite3_exec, which doesn't support parameter binding
 	if len(args) == 0 {
@@ -244,21 +244,21 @@ func (c *Conn) Exec(sql string, args ...interface{}) error {
 
 // Begin starts a new deferred transaction. This is equivalent to
 // c.Exec("BEGIN")
-// [https://www.sqlite.org/lang_transaction.html]
+// https://www.sqlite.org/lang_transaction.html
 func (c *Conn) Begin() error {
 	return c.exec(cStr("BEGIN\x00"))
 }
 
 // BeginImmediate starts a new deferred transaction. This is equivalent to
 // c.Exec("BEGIN IMMEDIATE")
-// [https://www.sqlite.org/lang_transaction.html]
+// https://www.sqlite.org/lang_transaction.html
 func (c *Conn) BeginImmediate() error {
 	return c.exec(cStr("BEGIN IMMEDIATE\x00"))
 }
 
 // BeginExclusive starts a new deferred transaction. This is equivalent to
 // c.Exec("BEGIN EXCLUSIVE")
-// [https://www.sqlite.org/lang_transaction.html]
+// https://www.sqlite.org/lang_transaction.html
 func (c *Conn) BeginExclusive() error {
 	return c.exec(cStr("BEGIN EXCLUSIVE\x00"))
 }
@@ -278,7 +278,7 @@ func (c *Conn) Rollback() error {
 // different from the one that is currently running the database operation, but
 // it is not safe to call this method on a connection that might close before
 // the call returns.
-// [https://www.sqlite.org/c3ref/interrupt.html]
+// https://www.sqlite.org/c3ref/interrupt.html
 func (c *Conn) Interrupt() {
 	if db := c.db; db != nil {
 		C.sqlite3_interrupt(db)
@@ -287,14 +287,14 @@ func (c *Conn) Interrupt() {
 
 // AutoCommit returns true if the database connection is in auto-commit mode
 // (i.e. outside of an explicit transaction started by BEGIN).
-// [https://www.sqlite.org/c3ref/get_autocommit.html]
+// https://www.sqlite.org/c3ref/get_autocommit.html
 func (c *Conn) AutoCommit() bool {
 	return C.sqlite3_get_autocommit(c.db) != 0
 }
 
 // LastInsertRowID returns the ROWID of the most recent successful INSERT
 // statement.
-// [https://www.sqlite.org/c3ref/last_insert_rowid.html]
+// https://www.sqlite.org/c3ref/last_insert_rowid.html
 func (c *Conn) LastInsertRowID() int64 {
 	return int64(C.sqlite3_last_insert_rowid(c.db))
 }
@@ -302,7 +302,7 @@ func (c *Conn) LastInsertRowID() int64 {
 // Changes returns the number of rows that were changed, inserted, or deleted
 // by the most recent statement. Auxiliary changes caused by triggers or
 // foreign key actions are not counted.
-// [https://www.sqlite.org/c3ref/changes.html]
+// https://www.sqlite.org/c3ref/changes.html
 func (c *Conn) Changes() int {
 	return int(C.sqlite3_changes(c.db))
 }
@@ -310,7 +310,7 @@ func (c *Conn) Changes() int {
 // TotalChanges returns the number of rows that were changed, inserted, or
 // deleted since the database connection was opened, including changes caused by
 // trigger and foreign key actions.
-// [https://www.sqlite.org/c3ref/total_changes.html]
+// https://www.sqlite.org/c3ref/total_changes.html
 func (c *Conn) TotalChanges() int {
 	return int(C.sqlite3_total_changes(c.db))
 }
@@ -323,7 +323,7 @@ func (c *Conn) TotalChanges() int {
 // during a call to Backup.Step. The source connection may be used for other
 // purposes between these calls. The destination connection must not be used for
 // anything until the backup is closed.
-// [https://www.sqlite.org/backup.html]
+// https://www.sqlite.org/backup.html
 func (c *Conn) Backup(srcName string, dst *Conn, dstName string) (*Backup, error) {
 	if c == dst || dst == nil {
 		return nil, ErrBadConn
@@ -341,7 +341,7 @@ func (c *Conn) Backup(srcName string, dst *Conn, dstName string) (*Backup, error
 // read-only. It is not possible to open a column that is part of an index or
 // primary key for writing. If foreign key constraints are enabled, it is not
 // possible to open a column that is part of a child key for writing.
-// [https://www.sqlite.org/c3ref/blob_open.html]
+// https://www.sqlite.org/c3ref/blob_open.html
 func (c *Conn) BlobIO(db, tbl, col string, row int64, rw bool) (*BlobIO, error) {
 	return newBlobIO(c, db, tbl, col, row, rw)
 }
@@ -350,14 +350,14 @@ func (c *Conn) BlobIO(db, tbl, col string, row int64, rw bool) (*BlobIO, error) 
 // locking operation for the specified duration before aborting. It returns the
 // callback function that was previously registered with Conn.BusyFunc, if any.
 // The busy handler is disabled if d is negative or zero.
-// [https://www.sqlite.org/c3ref/busy_timeout.html]
+// https://www.sqlite.org/c3ref/busy_timeout.html
 func (c *Conn) BusyTimeout(d time.Duration) {
 	C.sqlite3_busy_timeout(c.db, C.int(d/time.Millisecond))
 }
 
 // FileName returns the full file path of an attached database. An empty string
 // is returned for temporary databases.
-// [https://www.sqlite.org/c3ref/db_filename.html]
+// https://www.sqlite.org/c3ref/db_filename.html
 func (c *Conn) FileName(db string) string {
 	db += "\x00"
 	if path := C.sqlite3_db_filename(c.db, cStr(db)); path != nil {
@@ -369,7 +369,7 @@ func (c *Conn) FileName(db string) string {
 // Status returns the current and peak values of a connection performance
 // counter, specified by one of the DBSTATUS constants. If reset is true, the
 // peak value is reset back down to the current value after retrieval.
-// [https://www.sqlite.org/c3ref/db_status.html]
+// https://www.sqlite.org/c3ref/db_status.html
 func (c *Conn) Status(op int, reset bool) (cur, peak int, err error) {
 	var cCur, cPeak C.int
 	rc := C.sqlite3_db_status(c.db, C.int(op), &cCur, &cPeak, cBool(reset))
@@ -382,7 +382,7 @@ func (c *Conn) Status(op int, reset bool) (cur, peak int, err error) {
 // Limit changes a per-connection resource usage or performance limit, specified
 // by one of the LIMIT constants, returning its previous value. If the new value
 // is negative, the limit is left unchanged and its current value is returned.
-// [https://www.sqlite.org/c3ref/limit.html]
+// https://www.sqlite.org/c3ref/limit.html
 func (c *Conn) Limit(id, value int) (prev int) {
 	prev = int(C.sqlite3_limit(c.db, C.int(id), C.int(value)))
 	return
@@ -397,7 +397,7 @@ func (c *Conn) exec(sql *C.char) error {
 }
 
 // Stmt is a prepared statement handle.
-// [https://www.sqlite.org/c3ref/stmt.html]
+// https://www.sqlite.org/c3ref/stmt.html
 type Stmt struct {
 	stmt *C.sqlite3_stmt
 	Tail string
@@ -405,7 +405,7 @@ type Stmt struct {
 
 // Close releases all resources associated with the prepared statement. This
 // method can be called at any point in the statement's life cycle.
-// [https://www.sqlite.org/c3ref/finalize.html]
+// https://www.sqlite.org/c3ref/finalize.html
 func (s *Stmt) Close() error {
 	rc := C.sqlite3_finalize(s.stmt)
 	s.stmt = nil
@@ -423,28 +423,28 @@ func (s *Stmt) Busy() bool {
 
 // ReadOnly returns true if the prepared statement makes no direct changes to
 // the content of the database file.
-// [https://www.sqlite.org/c3ref/stmt_readonly.html]
+// https://www.sqlite.org/c3ref/stmt_readonly.html
 func (s *Stmt) ReadOnly() bool {
 	return C.sqlite3_stmt_readonly(s.stmt) != 0
 }
 
 // BindParameterCount returns the number of SQL parameters in the prepared
 // statement.
-// [https://www.sqlite.org/c3ref/bind_parameter_count.html]
+// https://www.sqlite.org/c3ref/bind_parameter_count.html
 func (s *Stmt) BindParameterCount() int {
 	return int(C.sqlite3_bind_parameter_count(s.stmt))
 }
 
 // ColumnCount returns the number of columns produced by the prepared
 // statement.
-// [https://www.sqlite.org/c3ref/column_count.html]
+// https://www.sqlite.org/c3ref/column_count.html
 func (s *Stmt) ColumnCount() int {
 	return int(C.sqlite3_column_count(s.stmt))
 }
 
 // // Params returns the names of bound parameters in the prepared statement. Nil
 // // is returned if the statement does not use named parameters.
-// // [https://www.sqlite.org/c3ref/bind_parameter_name.html]
+// // https://www.sqlite.org/c3ref/bind_parameter_name.html
 // func (s *Stmt) Params() []string {
 // 	if s.varNames == nil {
 // 		var names []string
@@ -469,14 +469,14 @@ func (s *Stmt) ColumnCount() int {
 
 // ColumnName returns the name of column produced by the prepared statement.
 // The leftmost column is number 0.
-// [https://www.sqlite.org/c3ref/column_name.html]
+// https://www.sqlite.org/c3ref/column_name.html
 func (s *Stmt) ColumnName(i int) string {
 	return C.GoString(C.sqlite3_column_name(s.stmt, C.int(i)))
 }
 
 // ColumnsNames returns the names of columns produced by the prepared
 // statement.
-// [https://www.sqlite.org/c3ref/column_name.html]
+// https://www.sqlite.org/c3ref/column_name.html
 func (s *Stmt) ColumnNames() []string {
 	nCols := s.ColumnCount()
 	names := make([]string, nCols)
@@ -488,14 +488,14 @@ func (s *Stmt) ColumnNames() []string {
 
 // DeclType returns the type declaration of columns produced by the prepared
 // statement. The leftmost column is number 0.
-// [https://www.sqlite.org/c3ref/column_decltype.html]
+// https://www.sqlite.org/c3ref/column_decltype.html
 func (s *Stmt) DeclType(i int) string {
 	return C.GoString(C.sqlite3_column_decltype(s.stmt, C.int(i)))
 }
 
 // DeclTypes returns the type declarations of columns produced by the prepared
 // statement.
-// [https://www.sqlite.org/c3ref/column_decltype.html]
+// https://www.sqlite.org/c3ref/column_decltype.html
 func (s *Stmt) DeclTypes() []string {
 	nCols := s.ColumnCount()
 	declTypes := make([]string, nCols)
@@ -579,7 +579,7 @@ func (s *Stmt) Bind(args ...interface{}) error {
 // into successive arguments. If the last argument is an instance of RowMap,
 // then all remaining column/value pairs are assigned into the map. The same row
 // may be scanned multiple times. Nil arguments are silently skipped.
-// [https://www.sqlite.org/c3ref/column_blob.html]
+// https://www.sqlite.org/c3ref/column_blob.html
 func (s *Stmt) Scan(dst ...interface{}) error {
 	n := len(dst)
 	if n == 0 {
@@ -600,7 +600,7 @@ func (s *Stmt) Scan(dst ...interface{}) error {
 // re-executed. This should be done when the remaining rows returned by a query
 // are not needed, which releases some resources that would otherwise persist
 // until the next call to Exec or Query.
-// [https://www.sqlite.org/c3ref/reset.html]
+// https://www.sqlite.org/c3ref/reset.html
 func (s *Stmt) Reset() error {
 	if rc := C.sqlite3_reset(s.stmt); rc != OK {
 		return errStr(rc)
@@ -610,7 +610,7 @@ func (s *Stmt) Reset() error {
 
 // ClearBindings clears the bindings on a prepared statement.  Reset does not
 // clear bindings.
-// [https://www.sqlite.org/c3ref/clear_bindings.html]
+// https://www.sqlite.org/c3ref/clear_bindings.html
 func (s *Stmt) ClearBindings() error {
 	if rc := C.sqlite3_clear_bindings(s.stmt); rc != OK {
 		return errStr(rc)
@@ -621,7 +621,7 @@ func (s *Stmt) ClearBindings() error {
 // Status returns the current value of a statement performance counter,
 // specified by one of the STMTSTATUS constants. If reset is true, the value is
 // reset back down to 0 after retrieval.
-// [https://www.sqlite.org/c3ref/stmt_status.html]
+// https://www.sqlite.org/c3ref/stmt_status.html
 func (s *Stmt) Status(op int, reset bool) int {
 	return int(C.sqlite3_stmt_status(s.stmt, C.int(op), cBool(reset)))
 }
@@ -677,7 +677,7 @@ func (s *Stmt) bindNamed(args NamedArgs) error {
 
 // Step evaluates the next step in the statement's program.  It returns true if
 // if a new row of data is ready for processing.
-// [https://www.sqlite.org/c3ref/step.html]
+// https://www.sqlite.org/c3ref/step.html
 func (s *Stmt) Step() (bool, error) {
 	rc := C.sqlite3_step(s.stmt)
 	if rc == DONE {
@@ -690,7 +690,7 @@ func (s *Stmt) Step() (bool, error) {
 
 // StepToCompletion is a convenience method that repeatedly calls Step until no
 // more rows are returned or an error occurs.
-// [https://www.sqlite.org/c3ref/step.html]
+// https://www.sqlite.org/c3ref/step.html
 func (s *Stmt) StepToCompletion() error {
 	for {
 		rc := C.sqlite3_step(s.stmt)
@@ -708,7 +708,7 @@ func (s *Stmt) StepToCompletion() error {
 // ColumnType returns the data type code of column i in the current row (one of
 // INTEGER, FLOAT, TEXT, BLOB, or NULL). The value becomes undefined after a
 // type conversion.
-// [https://www.sqlite.org/c3ref/column_blob.html]
+// https://www.sqlite.org/c3ref/column_blob.html
 func (s *Stmt) ColumnType(i int) byte {
 	return byte(C.sqlite3_column_type(s.stmt, C.int(i)))
 }
@@ -717,7 +717,7 @@ func (s *Stmt) ColumnType(i int) byte {
 // Possible data types are INTEGER, FLOAT, TEXT, BLOB, and NULL. These
 // represent the actual storage classes used by SQLite to store each value
 // before any conversion.
-// [https://www.sqlite.org/c3ref/column_blob.html]
+// https://www.sqlite.org/c3ref/column_blob.html
 func (s *Stmt) ColumnTypes() []byte {
 	n := s.ColumnCount()
 	colTypes := make([]byte, n)

--- a/sqlite3/util.go
+++ b/sqlite3/util.go
@@ -23,7 +23,7 @@ import (
 //
 // It is not possible to mix named and anonymous ("?") parameters in the same
 // statement.
-// [http://www.sqlite.org/lang_expr.html#varparam]
+// https://www.sqlite.org/lang_expr.html#varparam
 type NamedArgs map[string]interface{}
 
 type (
@@ -133,7 +133,7 @@ var (
 
 // Complete returns true if sql appears to contain a complete statement that is
 // ready to be parsed. This does not validate the statement syntax.
-// [http://www.sqlite.org/c3ref/complete.html]
+// https://www.sqlite.org/c3ref/complete.html
 func Complete(sql string) bool {
 	if initErr != nil {
 		return false
@@ -148,7 +148,7 @@ func Complete(sql string) bool {
 //
 // This function is currently a no-op because SQLite is not compiled with the
 // SQLITE_ENABLE_MEMORY_MANAGEMENT option.
-// [http://www.sqlite.org/c3ref/release_memory.html]
+// https://www.sqlite.org/c3ref/release_memory.html
 func ReleaseMemory(n int) int {
 	if initErr != nil {
 		return 0
@@ -160,7 +160,7 @@ func ReleaseMemory(n int) int {
 // that may be allocated by SQLite. A negative value for n keeps the current
 // limit, while 0 removes the limit. The previous limit value is returned, with
 // negative values indicating an error.
-// [http://www.sqlite.org/c3ref/soft_heap_limit64.html]
+// https://www.sqlite.org/c3ref/soft_heap_limit64.html
 func SoftHeapLimit(n int64) int64 {
 	if initErr != nil {
 		return -1
@@ -170,7 +170,7 @@ func SoftHeapLimit(n int64) int64 {
 
 // SourceID returns the check-in identifier of SQLite within its configuration
 // management system.
-// [http://www.sqlite.org/c3ref/c_source_id.html]
+// https://www.sqlite.org/c3ref/c_source_id.html
 func SourceID() string {
 	if initErr != nil {
 		return ""
@@ -181,7 +181,7 @@ func SourceID() string {
 // Status returns the current and peak values of a core performance
 // counter, specified by one of the STATUS constants. If reset is true, the peak
 // value is reset back down to the current value after retrieval.
-// [http://www.sqlite.org/c3ref/status.html]
+// https://www.sqlite.org/c3ref/status.html
 func Status(op int, reset bool) (cur, peak int, err error) {
 	if initErr != nil {
 		return 0, 0, initErr
@@ -195,7 +195,7 @@ func Status(op int, reset bool) (cur, peak int, err error) {
 }
 
 // Version returns the SQLite version as a string in the format "X.Y.Z[.N]".
-// [http://www.sqlite.org/c3ref/libversion.html]
+// https://www.sqlite.org/c3ref/libversion.html
 func Version() string {
 	if initErr != nil {
 		return ""


### PR DESCRIPTION
In the godoc syntax, it was showing the brackets around URLs, and occasionally the bracket was getting included in the URL and breaking the link.  This pull request fixes it by making URLs just plain.  Also, I took the opportunity to make links into https where possible.