### PR TITLE
Return original error on WithTx methods when Rollback doesn't return an error

### DIFF
--- a/sqlite3/sqlite3.go
+++ b/sqlite3/sqlite3.go
@@ -474,7 +474,7 @@ func (c *Conn) WithTx(f func() error) error {
 	err := f()
 	if err != nil {
 		err2 := c.Rollback()
-		if err2 != nil {
+		if err2 == nil {
 			return err
 		}
 		return fmt.Errorf("%v, additionally rolling back transaction failed: %v", err, err2)
@@ -499,7 +499,7 @@ func (c *Conn) WithTxImmediate(f func() error) error {
 	err := f()
 	if err != nil {
 		err2 := c.Rollback()
-		if err2 != nil {
+		if err2 == nil {
 			return err
 		}
 		return fmt.Errorf("%v, additionally rolling back transaction failed: %v", err, err2)
@@ -523,7 +523,7 @@ func (c *Conn) WithTxExclusive(f func() error) error {
 	err := f()
 	if err != nil {
 		err2 := c.Rollback()
-		if err2 != nil {
+		if err2 == nil {
 			return err
 		}
 		return fmt.Errorf("%v, additionally rolling back transaction failed: %v", err, err2)


### PR DESCRIPTION
When the function passed as parameter, henceforth fn, to the WithTx*
methods return an error a rollback is executed but if the rollback
doesn't return any error the WithTx function should return the original
error returned by fn.